### PR TITLE
add ava as test framework and nyc as coverage anilizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
+.nyc_output
 /node_modules

--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "0.5.0",
   "description": "The ToonAPI service wrapper for Node",
   "main": "index.js",
-  "scripts": {},
+  "scripts": {
+    "test": "ava",
+    "cover": "nyc ava"
+  },
   "repository": {
     "type": "git",
     "url": "git@github.com:JacoKoster/toonapi.git"
@@ -19,5 +22,9 @@
     "promise": "^7.3.0",
     "request": "^2.81.0",
     "request-promise": "^4.2.1"
+  },
+  "devDependencies": {
+    "ava": "0.22.0",
+    "nyc": "11.1.0"
   }
 }

--- a/test/Api.js
+++ b/test/Api.js
@@ -1,0 +1,9 @@
+import test from 'ava';
+import Api from '../helpers/Api';
+
+test('validateLogonData', t => {
+    const api = new Api();
+
+	t.deepEqual(api.validateLogonData(), "The logon object is required");
+	t.deepEqual(api.validateLogonData({}), "A client key is required");
+});


### PR DESCRIPTION
#6 
Hi Jaco,
I'd like to help in ToonAPI.
I'd like to recommend AVA for test framework. It has parallel test execution. So it makes AVA super fast for tests.
Also I've add NYC for coverage. Coverage will be quite useful for CI.
Example: 
<img width="536" alt="screen shot 2017-08-24 at 7 00 43 pm" src="https://user-images.githubusercontent.com/2780401/29675969-755afb18-88ff-11e7-93ab-7a5c34b5c62a.png">
